### PR TITLE
Fix: npm-uninstall typo

### DIFF
--- a/docs/content/commands/npm-uninstall.md
+++ b/docs/content/commands/npm-uninstall.md
@@ -30,7 +30,7 @@ It also removes the package from the `dependencies`, `devDependencies`,
 `optionalDependencies`, and `peerDependencies` objects in your
 `package.json`.
 
-Futher, if you have an `npm-shrinkwrap.json` or `package-lock.json`, npm
+Further, if you have an `npm-shrinkwrap.json` or `package-lock.json`, npm
 will update those files as well.
 
 `--no-save` will tell npm not to remove the package from your


### PR DESCRIPTION
This PR simply fixes a minor typo in the commands documentation:

`Futher --> Further`

ps: Happy to have contributed my *single letter* to the NPM Project! :rofl: :blue_heart: 